### PR TITLE
Add team builder and damage calc pages

### DIFF
--- a/pages/battle-simulator/damage-calc.tsx
+++ b/pages/battle-simulator/damage-calc.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import type { NextPage } from 'next';
+import FullBleedWrapper from '../../components/ui/FullBleedWrapper';
+
+const DamageCalcPage: NextPage = () => {
+  const [level, setLevel] = useState(50);
+  const [attack, setAttack] = useState(100);
+  const [defense, setDefense] = useState(100);
+  const [power, setPower] = useState(60);
+  const [damage, setDamage] = useState<number | null>(null);
+
+  const calculate = () => {
+    const dmg = Math.floor(((2 * level / 5 + 2) * power * attack / defense) / 50) + 2;
+    setDamage(dmg);
+  };
+
+  return (
+    <FullBleedWrapper>
+      <div className="max-w-md mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Damage Calculator</h1>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium">Level</label>
+            <input
+              type="number"
+              className="w-full border rounded p-2 text-black"
+              value={level}
+              onChange={e => setLevel(Number(e.target.value))}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Attack</label>
+            <input
+              type="number"
+              className="w-full border rounded p-2 text-black"
+              value={attack}
+              onChange={e => setAttack(Number(e.target.value))}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Defense</label>
+            <input
+              type="number"
+              className="w-full border rounded p-2 text-black"
+              value={defense}
+              onChange={e => setDefense(Number(e.target.value))}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Move Power</label>
+            <input
+              type="number"
+              className="w-full border rounded p-2 text-black"
+              value={power}
+              onChange={e => setPower(Number(e.target.value))}
+            />
+          </div>
+          <button
+            onClick={calculate}
+            className="w-full px-4 py-2 bg-blue-500 text-white rounded"
+          >
+            Calculate
+          </button>
+        </div>
+        {damage !== null && (
+          <p className="mt-4 text-lg font-semibold">Estimated Damage: {damage}</p>
+        )}
+      </div>
+    </FullBleedWrapper>
+  );
+};
+
+export default DamageCalcPage;

--- a/pages/battle-simulator/team-builder.tsx
+++ b/pages/battle-simulator/team-builder.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import type { NextPage } from 'next';
+import FullBleedWrapper from '../../components/ui/FullBleedWrapper';
+
+const TeamBuilderPage: NextPage = () => {
+  const [team, setTeam] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  const addPokemon = () => {
+    if (!input.trim()) return;
+    setTeam(prev => [...prev, input.trim()].slice(0, 6));
+    setInput('');
+  };
+
+  const removePokemon = (idx: number) => {
+    setTeam(prev => prev.filter((_, i) => i !== idx));
+  };
+
+  return (
+    <FullBleedWrapper>
+      <div className="max-w-2xl mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Team Builder</h1>
+        <div className="flex items-center">
+          <input
+            type="text"
+            className="flex-grow border rounded p-2 mr-2 text-black"
+            placeholder="Enter Pokémon name"
+            value={input}
+            onChange={e => setInput(e.target.value)}
+          />
+          <button
+            onClick={addPokemon}
+            className="px-4 py-2 bg-blue-500 text-white rounded"
+          >
+            Add
+          </button>
+        </div>
+        <ul className="mt-4 space-y-2">
+          {team.map((mon, idx) => (
+            <li
+              key={idx}
+              className="flex justify-between items-center border-b pb-1"
+            >
+              <span>{idx + 1}. {mon}</span>
+              <button onClick={() => removePokemon(idx)} className="text-red-600">Remove</button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </FullBleedWrapper>
+  );
+};
+
+export default TeamBuilderPage;


### PR DESCRIPTION
## Summary
- create pages for team builder and damage calculator under `pages/battle-simulator`
- keep navbar links to these new pages

## Testing
- `npm install --ignore-scripts`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687da55751cc8327acc1d842a3162edb