### PR TITLE
Fix navigation reloads with Next.js router

### DIFF
--- a/components/GlobalErrorHandler.tsx
+++ b/components/GlobalErrorHandler.tsx
@@ -29,7 +29,7 @@ export default function GlobalErrorHandler(): null {
           // Reload the page once to try recovering
           if (!window.__hasReloaded) {
             window.__hasReloaded = true;
-            window.location.reload();
+            router.reload();
           }
         }
       }
@@ -47,7 +47,7 @@ export default function GlobalErrorHandler(): null {
         
         if (process.env.NODE_ENV === 'production' && !window.__hasReloaded) {
           window.__hasReloaded = true;
-          window.location.reload();
+          router.reload();
         }
       }
     };

--- a/components/TCGSetsErrorBoundary.tsx
+++ b/components/TCGSetsErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, ErrorInfo } from 'react';
+import Router from 'next/router';
 
 interface TCGSetsErrorBoundaryProps {
   children: ReactNode;
@@ -30,7 +31,7 @@ class TCGSetsErrorBoundary extends React.Component<TCGSetsErrorBoundaryProps, TC
   handleReset(): void {
     this.setState({ hasError: false, errorInfo: null });
     // Force a page reload to clear any module state
-    window.location.reload();
+    Router.reload();
   }
 
   override render(): ReactNode {

--- a/components/layout/ErrorBoundary.tsx
+++ b/components/layout/ErrorBoundary.tsx
@@ -50,7 +50,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
             
             <div className="space-y-3">
               <button
-                onClick={() => window.location.reload()}
+                onClick={() => Router.reload()}
                 className="w-full px-6 py-3 bg-pokemon-red text-white rounded-lg hover:bg-red-700 transition-colors"
               >
                 Refresh Page

--- a/components/mobile/MobileIntegration.tsx
+++ b/components/mobile/MobileIntegration.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, ReactNode } from 'react';
+import { useRouter } from 'next/router';
 import { useMobileUtils } from '../../utils/mobileUtils';
 import adaptiveLoading from '../../utils/adaptiveLoading';
 import batteryOptimization from '../../utils/batteryOptimization';
@@ -92,6 +93,7 @@ const MobileIntegration: React.FC<MobileIntegrationProps> = ({
   onShare
 }) => {
   const { isMobile, utils } = useMobileUtils();
+  const router = useRouter();
   const isStandalone = utils.isStandalone;
   const [mobileFeatures, setMobileFeatures] = useState<MobileFeatures>({
     loading: adaptiveLoading.getCurrentStrategy(),
@@ -417,7 +419,7 @@ const MobileIntegration: React.FC<MobileIntegrationProps> = ({
             onClick={() => handleShare({
               title: 'DexTrends - Pokemon TCG Price Tracker',
               text: 'Check out DexTrends for Pokemon card prices!',
-              url: window.location.href
+              url: `${window.location.origin}${router.asPath}`
             })}
             className="w-full p-3 bg-blue-500 text-white rounded-lg font-medium">
 
@@ -428,7 +430,7 @@ const MobileIntegration: React.FC<MobileIntegrationProps> = ({
             onClick={() => handleShare({
               title: document.title,
               text: 'Found this on DexTrends!',
-              url: window.location.href
+              url: `${window.location.origin}${router.asPath}`
             })}
             className="w-full p-3 bg-green-500 text-white rounded-lg font-medium">
 

--- a/components/mobile/MobileShare.tsx
+++ b/components/mobile/MobileShare.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { useRouter } from 'next/router';
 import { useMobileUtils } from '../../utils/mobileUtils';
 import logger from '../../utils/logger';
 
@@ -62,6 +63,7 @@ const MobileShare: React.FC<MobileShareProps> = ({
   showFallbackOptions = true
 }) => {
   const { utils } = useMobileUtils();
+  const router = useRouter();
   const [isSharing, setIsSharing] = useState(false);
   const [showShareMenu, setShowShareMenu] = useState(false);
   const [isSupported] = useState(() => {
@@ -140,7 +142,7 @@ const MobileShare: React.FC<MobileShareProps> = ({
     return {
       title: title || 'Check out DexTrends',
       text: text || 'Discover Pokemon card prices and trends with DexTrends!',
-      url: url || window.location.href,
+      url: url || `${window.location.origin}${router.asPath}`,
       image
     };
   }, [cardData, title, text, url, image]);

--- a/components/pwa/AppUpdateNotification.tsx
+++ b/components/pwa/AppUpdateNotification.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { useMobileUtils } from '../../utils/mobileUtils';
 import logger from '../../utils/logger';
 
@@ -18,6 +19,7 @@ interface ServiceWorkerMessage {
 
 const AppUpdateNotification: React.FC = () => {
   const { utils } = useMobileUtils();
+  const router = useRouter();
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [appUpdated, setAppUpdated] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
@@ -128,7 +130,7 @@ const AppUpdateNotification: React.FC = () => {
         
         // Reload the page to get the new version
         setTimeout(() => {
-          window.location.reload();
+          router.reload();
         }, 1000);
       }
     } catch (error) {

--- a/components/pwa/PWAProvider.tsx
+++ b/components/pwa/PWAProvider.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { useRouter } from 'next/router';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -36,6 +37,7 @@ export const PWAProvider: React.FC<PWAProviderProps> = ({ children }) => {
   const [isOnline, setIsOnline] = useState(true);
   const [serviceWorkerRegistration, setServiceWorkerRegistration] = useState<ServiceWorkerRegistration | null>(null);
   const [hasUpdate, setHasUpdate] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     // Check if app is installed/standalone
@@ -117,7 +119,7 @@ export const PWAProvider: React.FC<PWAProviderProps> = ({ children }) => {
   const refreshApp = (): void => {
     if (serviceWorkerRegistration && serviceWorkerRegistration.waiting) {
       serviceWorkerRegistration.waiting.postMessage({ type: 'SKIP_WAITING' });
-      window.location.reload();
+      router.reload();
     }
   };
 

--- a/components/qol/ContextualHelp.tsx
+++ b/components/qol/ContextualHelp.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, ReactNode } from 'react';
-import { useRouter } from 'next/router';
+import Router, { useRouter } from 'next/router';
 import { useNotifications } from './NotificationSystem';
 import logger from '../../utils/logger';
 
@@ -379,7 +379,7 @@ export class SmartErrorBoundary extends React.Component<SmartErrorBoundaryProps,
               
               <div className="space-y-2">
                 <button
-                  onClick={() => window.location.reload()}
+                  onClick={() => Router.reload()}
                   className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors">
 
                   Refresh Page

--- a/components/qol/KeyboardShortcuts.tsx
+++ b/components/qol/KeyboardShortcuts.tsx
@@ -109,7 +109,7 @@ export const KeyboardShortcutsManager: React.FC = () => {
       title: 'Refresh Page',
       description: 'Reload the current page',
       icon: '🔄',
-      action: () => window.location.reload(),
+      action: () => router.reload(),
       keywords: ['refresh', 'reload', 'update']
     }
   ];

--- a/components/ui/AdvancedKeyboardShortcuts.tsx
+++ b/components/ui/AdvancedKeyboardShortcuts.tsx
@@ -230,7 +230,7 @@ const AdvancedKeyboardShortcuts: React.FC<AdvancedKeyboardShortcutsProps> = ({
       description: 'Reload current data',
       icon: <ArrowPathIcon className="h-4 w-4" />,
       category: 'quick',
-      action: () => window.location.reload(),
+      action: () => router.reload(),
       shortcut: 'f5'
     },
     'quick:share-page': {
@@ -239,7 +239,7 @@ const AdvancedKeyboardShortcuts: React.FC<AdvancedKeyboardShortcutsProps> = ({
       icon: <ShareIcon className="h-4 w-4" />,
       category: 'quick',
       action: () => {
-        navigator.clipboard.writeText(window.location.href);
+        navigator.clipboard.writeText(`${window.location.origin}${router.asPath}`);
         notify.success('Page link copied to clipboard');
       },
       shortcut: 'ctrl+shift+s'

--- a/components/ui/FloatingActionSystem.tsx
+++ b/components/ui/FloatingActionSystem.tsx
@@ -1,7 +1,7 @@
-import React, { 
-  useState, 
-  useEffect, 
-  useRef, 
+import React, {
+  useState,
+  useEffect,
+  useRef,
   useCallback,
   createContext,
   useContext,
@@ -9,6 +9,7 @@ import React, {
   ReactNode,
   CSSProperties
 } from 'react';
+import { useRouter } from 'next/router';
 import { HapticFeedback, VisualFeedback } from './MicroInteractionSystem';
 
 /**
@@ -486,6 +487,7 @@ export const SpeedDialFAB: React.FC<SpeedDialFABProps> = ({
 // Contextual FAB Hook
 export const useContextualFAB = () => {
   const { setGlobalFABConfig, clearGlobalFAB } = useFAB();
+  const router = useRouter();
   
   const showFAB = useCallback((config: FABConfig) => {
     setGlobalFABConfig(config);
@@ -535,7 +537,7 @@ export const useContextualFAB = () => {
         ),
         label: 'Share to Twitter',
         onClick: () => {
-          const url = shareOptions.url || window.location.href;
+          const url = shareOptions.url || `${window.location.origin}${router.asPath}`;
           const text = shareOptions.text || 'Check this out!';
           window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`, '_blank');
         }
@@ -548,7 +550,7 @@ export const useContextualFAB = () => {
         ),
         label: 'Copy link',
         onClick: () => {
-          const url = shareOptions.url || window.location.href;
+          const url = shareOptions.url || `${window.location.origin}${router.asPath}`;
           navigator.clipboard.writeText(url);
           HapticFeedback.success();
         }

--- a/components/ui/PageErrorBoundary.tsx
+++ b/components/ui/PageErrorBoundary.tsx
@@ -15,6 +15,7 @@ interface State {
 
 // Default error fallback component
 const DefaultErrorFallback = ({ error, resetError }: { error: Error; resetError: () => void }) => {
+  const router = useRouter();
   return (
     <div className="min-h-[50vh] flex items-center justify-center p-8">
       <div className="max-w-md w-full bg-white dark:bg-gray-800 rounded-lg shadow-xl p-8 text-center">
@@ -35,7 +36,7 @@ const DefaultErrorFallback = ({ error, resetError }: { error: Error; resetError:
             Try Again
           </button>
           <button
-            onClick={() => window.location.href = '/'}
+            onClick={() => router.push('/')}
             className="w-full px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-white font-medium rounded-lg transition-colors"
           >
             Go to Homepage

--- a/components/ui/SocialCommunityHub.tsx
+++ b/components/ui/SocialCommunityHub.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { FaUsers, FaComments, FaTrophy, FaHeart, FaShare, FaStar, FaFire, FaCrown } from 'react-icons/fa';
 import { BsChatDots, BsHeart, BsShare, BsBookmark, BsThreeDots } from 'react-icons/bs';
 
@@ -97,6 +98,7 @@ interface Tab {
 }
 
 const SocialCommunityHub: React.FC = () => {
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState<TabId>('feed');
   const [socialData, setSocialData] = useState<SocialData>({
     posts: [],
@@ -322,14 +324,14 @@ const SocialCommunityHub: React.FC = () => {
         await navigator.share({
           title: `${post.user.username} shared on DexTrends`,
           text: post.content,
-          url: window.location.href
+          url: `${window.location.origin}${router.asPath}`
         });
       } catch (error) {
         console.log('Share cancelled');
       }
     } else {
       // Fallback to clipboard
-      navigator.clipboard.writeText(window.location.href);
+      navigator.clipboard.writeText(`${window.location.origin}${router.asPath}`);
       // Show notification
     }
   };

--- a/components/ui/charts/PriceHistoryChart.tsx
+++ b/components/ui/charts/PriceHistoryChart.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { useTheme } from '../../../context/UnifiedAppContext';
 import { PriceHistoryManager } from '../../../lib/supabase';
 import { 
@@ -20,6 +21,7 @@ interface PriceHistoryChartProps {
 }
 
 export default function PriceHistoryChart({ cardId, variantType = 'market', initialPrice = 0 }: PriceHistoryChartProps) {
+  const router = useRouter();
   const { theme } = useTheme();
   const [priceData, setPriceData] = useState<unknown[]>([]);
   const [loading, setLoading] = useState(true);
@@ -302,7 +304,7 @@ export default function PriceHistoryChart({ cardId, variantType = 'market', init
         <p className="text-red-600 dark:text-red-400 font-medium">Error loading price data</p>
         <p className="text-sm text-red-500 dark:text-red-300 mt-1">{error}</p>
         <button
-          onClick={() => window.location.reload()}
+          onClick={() => router.reload()}
           className="mt-3 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
         >
           Retry

--- a/components/ui/loading/PokemonEmptyState.tsx
+++ b/components/ui/loading/PokemonEmptyState.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 interface PokemonEmptyStateProps {
   type?: 'search' | 'collection' | 'cards' | 'error' | 'maintenance';
@@ -12,6 +13,7 @@ const PokemonEmptyState = ({
   type = "search",
   customMessage = null, actionButton = null, showAnimation = true 
 }: PokemonEmptyStateProps) => {
+  const router = useRouter();
   const [currentMessage, setCurrentMessage] = useState(0);
 
   const emptyStateData = {
@@ -246,8 +248,8 @@ const PokemonEmptyState = ({
             </Link>
             
             {type === 'search' && (
-              <button 
-                onClick={() => window.location.reload()} 
+              <button
+                onClick={() => router.reload()}
                 className="bg-pokemon-blue hover:bg-blue-700 text-white px-6 py-3 rounded-lg font-medium transition-all duration-300 hover:scale-105"
               >
                 🔄 Try Again
@@ -263,8 +265,8 @@ const PokemonEmptyState = ({
             )}
             
             {type === 'error' && (
-              <button 
-                onClick={() => window.location.reload()} 
+              <button
+                onClick={() => router.reload()}
                 className="bg-green-500 hover:bg-green-600 text-white px-6 py-3 rounded-lg font-medium transition-all duration-300 hover:scale-105"
               >
                 ⚡ Revive Page


### PR DESCRIPTION
## Summary
- replace `window.location` refreshes with Next.js `router` calls
- adjust sharing helpers to use `router.asPath`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: 1372 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_687dd932f0a08327ac530361407cb83e